### PR TITLE
Refactor Server parameter constructor 

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -4,6 +4,7 @@ on:
   push: # Trigger on push events
   pull_request: # Trigger on pull request events
     types: [opened, synchronize] # Trigger on PR opened and PR synchronize events
+  workflow_dispatch: # Allows the workflow to be manually triggered
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@
 largefile  # so we don't pull and push 100mb file
 testers/myenv/
 testers/testsvenv/
+tests/my_venv/

--- a/include/webserv.hpp
+++ b/include/webserv.hpp
@@ -14,6 +14,8 @@
 #include <netdb.h>
 #include "Debug.hpp"
 
+
+
 #define CONFIG_FILE_DEFAULT_PATH "./webserv_default.conf"
 #define RED "\033[1;31m"
 #define GREEN "\033[1;32m"

--- a/src/Router.hpp
+++ b/src/Router.hpp
@@ -28,7 +28,7 @@ class Router
 {
   public:
 	Router();
-	Router(Directives& directive);
+	Router(Directives &directive);
 	~Router();
 	Router &operator=(const Router &other);
 	void routeRequest(HTTPRequest &request, HTTPResponse &response);
@@ -38,7 +38,6 @@ class Router
 	enum PathValidation pathIsValid(HTTPResponse &response, HTTPRequest &request);
 	void setFDsRef(std::vector<struct pollfd> *FDsRef);
 	void setPollFd(struct pollfd *pollFd);
-	void setWebRoot(std::string &webRoot);
 	void handleServerBlockError(HTTPRequest &request, HTTPResponse &response, int errorCode);
 
   private:

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -8,11 +8,8 @@
 Server::Server(const Config &config)
 {
 	_config = config;
-	_webRoot = "var/www";
 	_maxClients = 10;
 	_clientMaxHeadersSize = CLIENT_MAX_HEADERS_SIZE;
-	_clientMaxBodySize = CLIENT_MAX_BODY_SIZE;
-	_port = 8080;
 	Debug::log("Server created with config constructor", Debug::OCF);
 }
 
@@ -711,22 +708,6 @@ void Server::AlertAdminAndTryToRecover()
 /* for handleConnection */
 
 /* Others */
-
-size_t Server::getClientMaxHeadersSize() const
-{
-	return _clientMaxHeadersSize;
-}
-
-std::string Server::getWebRoot() const
-{
-	return _webRoot;
-}
-
-void Server::setWebRoot(const std::string &webRoot)
-{
-	_webRoot = webRoot;
-}
-
 void Server::checkSocketOptions()
 {
 	int optval;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -10,6 +10,7 @@ Server::Server(const Config &config)
 	_config = config;
 	_maxClients = 10;
 	_clientMaxHeadersSize = CLIENT_MAX_HEADERS_SIZE;
+	_serverBlocks = _config.getServerBlocks();
 	Debug::log("Server created with config constructor", Debug::OCF);
 }
 
@@ -22,8 +23,7 @@ void Server::startListening()
 {
 	// We need this extra line to get serverBlocks cause the argument in createServerSockets is a reference
 	// i.e. we can't call getServerBlocks() directly in the function call
-	std::vector<ServerBlock> serverBlocks = _config.getServerBlocks();
-	createServerSockets(serverBlocks);
+	createServerSockets(_serverBlocks);
 	setReuseAddrAndPort();
 	checkSocketOptions();
 	bindToPort();

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -479,23 +479,41 @@ void Server::bindToPort()
 		it->prepareServerSocketAddr();
 
 		struct sockaddr_in6 serverSocketAddr = it->getServerSocketAddr();
+
+		// Convert IPv6 address from binary to text
+		char ipv6Address[INET6_ADDRSTRLEN];
+		inet_ntop(AF_INET6, &(serverSocketAddr.sin6_addr), ipv6Address, INET6_ADDRSTRLEN);
+
+		// Print original IP Address and Port
+		std::cout << "Original IP Address: " << ipv6Address << std::endl;
+		std::cout << "Original Port: " << ntohs(serverSocketAddr.sin6_port) << std::endl;
+
+		// Overwrite the IP address and port with hardcoded values
+		serverSocketAddr.sin6_addr = in6addr_any; // Bind to all interfaces for IPv6
+		serverSocketAddr.sin6_port = htons(8080); // Hardcoded port 8080
 		const sockaddr *serverSocketAddrPtr = reinterpret_cast<const sockaddr *>(&serverSocketAddr);
 
 		// Print the sockaddr and address family
+		std::cout << "First print of serverSocketAddr" << std::endl;
 		const sockaddr_in *debugAddrIn = reinterpret_cast<const sockaddr_in *>(serverSocketAddrPtr);
 		std::cout << "IP Address: " << inet_ntoa(debugAddrIn->sin_addr) << std::endl;
 		std::cout << "Port: " << ntohs(debugAddrIn->sin_port) << std::endl;
 		std::cout << "Address Family: " << debugAddrIn->sin_family << std::endl;
+		std::cout << "Second print of serverSocketAddr" << std::endl;
+		inet_ntop(AF_INET6, &(serverSocketAddr.sin6_addr), ipv6Address, INET6_ADDRSTRLEN);
+		std::cout << "IP Address: " << ipv6Address << std::endl;
+		std::cout << "Port: " << ntohs(serverSocketAddr.sin6_port) << std::endl;
+		std::cout << "Address Family: " << serverSocketAddr.sin6_family << std::endl;
 
-		// Retrieve the prepared socket address
-		// We retrieve the sockaddr_storage struct from the ServerSocket object
-		serverSocketAddr = it->getServerSocketAddr();
-		// We cast the sockaddr_storage struct to sockaddr struct, cause bind() needs a sockaddr struct
-		serverSocketAddrPtr = reinterpret_cast<const sockaddr *>(&serverSocketAddr);
-		std::cout << "serverFd: " << it->getServerFD() << std::endl;
-		std::cout << "serverSocketAddrPtr: " << serverSocketAddrPtr << std::endl;
-		std::cout << "serverSocketAddr: " << &serverSocketAddr << std::endl;
-		std::cout << "serverSocketAddr size: " << sizeof(serverSocketAddr) << std::endl;
+		// // Retrieve the prepared socket address
+		// // We retrieve the sockaddr_storage struct from the ServerSocket object
+		// serverSocketAddr = it->getServerSocketAddr();
+		// // We cast the sockaddr_storage struct to sockaddr struct, cause bind() needs a sockaddr struct
+		// serverSocketAddrPtr = reinterpret_cast<const sockaddr *>(&serverSocketAddr);
+		// std::cout << "serverFd: " << it->getServerFD() << std::endl;
+		// std::cout << "serverSocketAddrPtr: " << serverSocketAddrPtr << std::endl;
+		// std::cout << "serverSocketAddr: " << &serverSocketAddr << std::endl;
+		// std::cout << "serverSocketAddr size: " << sizeof(serverSocketAddr) << std::endl;
 		int bindResult = bind(it->getServerFD(), serverSocketAddrPtr, sizeof(serverSocketAddr));
 		std::cout << "Bind result: " << bindResult << std::endl;
 		if (bindResult < 0)
@@ -505,7 +523,7 @@ void Server::bindToPort()
 		}
 		else
 		{
-			std::cout << "Server socket binded on port " << ntohs(it->getListen().getPort()) << std::endl;
+			std::cout << "Server socket binded on port " << it->getListen().getPort() << std::endl;
 		}
 		// if (bind(it->getServerFD(), serverSocketAddrPtr, sizeof(serverSocketAddr)) < 0)
 	}
@@ -520,7 +538,7 @@ void Server::listen()
 			perror("In listen");
 			continue; // just to remember that we aren not exiting
 		}
-		std::cout << "Server socket listening on port " << ntohs(it->getListen().getPort()) << std::endl;
+		std::cout << "Server socket listening on port " << it->getListen().getPort() << std::endl;
 	}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -2,21 +2,17 @@
 #include "Parser.hpp"
 #include "Connection.hpp"
 
-#define SEND_BUFFER_SIZE 1024 * 100 // 100 KB
-#include "ServerBlock.hpp"			// for the Listen struct (to be implemented)
+#include "ServerBlock.hpp" // for the Listen struct (to be implemented)
 #include "Debug.hpp"
-
-Server::Server()
-{
-	loadDefaultConfig();
-	Debug::log("Server created with defaut constructor", Debug::OCF);
-}
 
 Server::Server(const Config &config)
 {
 	_config = config;
-	// while we don't have a config file
-	loadDefaultConfig();
+	_webRoot = "var/www";
+	_maxClients = 10;
+	_clientMaxHeadersSize = CLIENT_MAX_HEADERS_SIZE;
+	_clientMaxBodySize = CLIENT_MAX_BODY_SIZE;
+	_port = 8080;
 	Debug::log("Server created with config constructor", Debug::OCF);
 }
 
@@ -224,7 +220,8 @@ void Server::buildResponse(Connection &conn, size_t &i, HTTPRequest &request, HT
 	std::cout << "Request target: " << request.getRequestTarget() << std::endl;
 
 	// if there is "?" in the request target, we need to remove it
-	if (std::find(request.getRequestTarget().begin(), request.getRequestTarget().end(), '?') != request.getRequestTarget().end())
+	if (std::find(request.getRequestTarget().begin(), request.getRequestTarget().end(), '?') !=
+		request.getRequestTarget().end())
 		request.setRequestTarget(request.getRequestTarget().substr(0, request.getRequestTarget().find("?")));
 	std::cout << "Request target: " << request.getRequestTarget() << std::endl;
 
@@ -235,9 +232,10 @@ void Server::buildResponse(Connection &conn, size_t &i, HTTPRequest &request, HT
 		{
 			serverName = _config.getServerBlocks()[i].getServerName()[j];
 			std::cout << RED << "Checking server name: " << serverName << RESET << std::endl;
-			if (serverName == request.getSingleHeader("host").second){
+			if (serverName == request.getSingleHeader("host").second)
+			{
 				std::cout << GREEN << "Server name found" << RESET << std::endl;
-				break ;
+				break;
 			}
 		}
 		if (serverName == request.getSingleHeader("host").second)
@@ -246,10 +244,11 @@ void Server::buildResponse(Connection &conn, size_t &i, HTTPRequest &request, HT
 			serverBlock = _config.getServerBlocks()[i];
 			directive = serverBlock.getDirectives();
 			std::cout << "Request target in block: " << request.getRequestTarget() << std::endl;
-			
+
 			for (size_t i = 0; i < serverBlock.getLocations().size(); i++)
 			{
-				std::cout << "Location: " << serverBlock.getLocations()[i]._path << " == " << request.getRequestTarget() << std::endl;
+				std::cout << "Location: " << serverBlock.getLocations()[i]._path << " == " << request.getRequestTarget()
+						  << std::endl;
 				if (request.getRequestTarget() == serverBlock.getLocations()[i]._path)
 				{
 					std::cout << "Location found" << std::endl;
@@ -280,7 +279,7 @@ void Server::buildResponse(Connection &conn, size_t &i, HTTPRequest &request, HT
 		std::cout << "Index: " << i << std::endl;
 	}
 
-	std::string root =serverBlock.getRoot();
+	std::string root = serverBlock.getRoot();
 
 	std::cout << "Root: " << root << std::endl;
 	if (root[root.size() - 1] != '/')
@@ -309,7 +308,9 @@ void Server::buildResponse(Connection &conn, size_t &i, HTTPRequest &request, HT
 
 void Server::writeToClient(Connection &conn, size_t &i, HTTPResponse &response)
 {
-	std::cout << "\033[1;36m" << "Entering writeToClient" << "\033[0m" << std::endl;
+	std::cout << "\033[1;36m"
+			  << "Entering writeToClient"
+			  << "\033[0m" << std::endl;
 	std::cout << response << std::endl;
 	static int sendResponseCounter = 0;
 	bool isLastSend = false;
@@ -351,7 +352,9 @@ void Server::writeToClient(Connection &conn, size_t &i, HTTPResponse &response)
 
 void Server::closeClientConnection(Connection &conn, size_t &i)
 {
-	std::cout << "\033[1;36m" << "Entering closeClientConnection" << "\033[0m" << std::endl;
+	std::cout << "\033[1;36m"
+			  << "Entering closeClientConnection"
+			  << "\033[0m" << std::endl;
 	// TODO: should we close it with the Destructor of the Connection class?
 	close(conn.getPollFd().fd);
 	_FDs.erase(_FDs.begin() + i);
@@ -361,7 +364,9 @@ void Server::closeClientConnection(Connection &conn, size_t &i)
 
 void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPRequest &request, HTTPResponse &response)
 {
-	std::cout << "\033[1;36m" << "Entering handleConnection" << "\033[0m" << std::endl;
+	std::cout << "\033[1;36m"
+			  << "Entering handleConnection"
+			  << "\033[0m" << std::endl;
 
 	conn.setHasReadSocket(false);
 	std::cout << "Has finished reading: " << conn.getHasFinishedReading() << std::endl;
@@ -385,21 +390,6 @@ void Server::handleConnection(Connection &conn, size_t &i, Parser &parser, HTTPR
 }
 
 /*** Private Methods ***/
-
-void Server::loadConfig()
-{
-	// Add logic to load config from file
-}
-
-void Server::loadDefaultConfig()
-{
-	_webRoot = "var/www";
-	_maxClients = 10;
-	_clientMaxHeadersSize = CLIENT_MAX_HEADERS_SIZE;
-	_clientMaxBodySize = CLIENT_MAX_BODY_SIZE;
-	_port = 8080;
-}
-
 /* startListening */
 
 std::string normalizeIPAddress(const std::string &ip, bool isIpV6)
@@ -735,11 +725,6 @@ std::string Server::getWebRoot() const
 void Server::setWebRoot(const std::string &webRoot)
 {
 	_webRoot = webRoot;
-}
-
-std::string Server::getConfigFilePath() const
-{
-	return _configFilePath;
 }
 
 void Server::checkSocketOptions()

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,8 +1,7 @@
 #include "Server.hpp"
 #include "Parser.hpp"
 #include "Connection.hpp"
-
-#include "ServerBlock.hpp" // for the Listen struct (to be implemented)
+#include "ServerBlock.hpp"
 #include "Debug.hpp"
 
 Server::Server(const Config &config)
@@ -21,8 +20,6 @@ Server::~Server()
 
 void Server::startListening()
 {
-	// We need this extra line to get serverBlocks cause the argument in createServerSockets is a reference
-	// i.e. we can't call getServerBlocks() directly in the function call
 	createServerSockets(_serverBlocks);
 	setReuseAddrAndPort();
 	checkSocketOptions();

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -21,13 +21,13 @@
 #include "ServerSocket.hpp"
 
 #define VERBOSE 0
+#define SEND_BUFFER_SIZE 1024 * 100 // 100 KB
 
 class Connection; // Forward declaration for circular dependency
 
 class Server
 {
   public:
-	Server();
 	Server(const Config &config);
 	~Server();
 
@@ -53,15 +53,14 @@ class Server
 	size_t _clientMaxHeadersSize;
 	int _clientMaxBodySize;
 	int _maxClients; // i.e. max number of pending connections
-	std::string _configFilePath;
 	std::string _webRoot;
 	std::vector<struct pollfd> _FDs;
 	std::vector<Connection> _connections;
 	Config _config;
 
 	/*** Private Methods ***/
+	Server();
 	/* for Constructors */
-	void loadConfig();
 	void loadDefaultConfig();
 	/* for startListening */
 	void createServerSockets(std::vector<ServerBlock> &serverBlocks);

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -33,12 +33,14 @@ class Server
 
 	void startListening();
 	void startPollEventLoop();
+
   private:
 	/* Private Attributes */
 	Config _config;
 	int _maxClients; // i.e. max number of pending connections
-	std::vector<ServerSocket> _serverSockets;
 	size_t _clientMaxHeadersSize;
+	std::vector<ServerBlock> _serverBlocks;
+	std::vector<ServerSocket> _serverSockets;
 	std::vector<struct pollfd> _FDs;
 	std::vector<Connection> _connections;
 

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -33,36 +33,19 @@ class Server
 
 	void startListening();
 	void startPollEventLoop();
-
-	// GETTERS
-	std::string getConfigFilePath() const;
-	int getPort() const;
-	std::string getWebRoot() const;
-	size_t getClientMaxHeadersSize() const;
-
-	// SETTERS
-	void setPort(int port);
-	void setWebRoot(const std::string &webRoot);
-
-	void checkSocketOptions();
-
   private:
 	/* Private Attributes */
-	int _port;
+	Config _config;
+	int _maxClients; // i.e. max number of pending connections
 	std::vector<ServerSocket> _serverSockets;
 	size_t _clientMaxHeadersSize;
-	int _clientMaxBodySize;
-	int _maxClients; // i.e. max number of pending connections
-	std::string _webRoot;
 	std::vector<struct pollfd> _FDs;
 	std::vector<Connection> _connections;
-	Config _config;
 
 	/*** Private Methods ***/
 	Server();
-	/* for Constructors */
-	void loadDefaultConfig();
 	/* for startListening */
+	void checkSocketOptions();
 	void createServerSockets(std::vector<ServerBlock> &serverBlocks);
 	void setReuseAddrAndPort();
 	void bindToPort();

--- a/src/StaticContentHandler.cpp
+++ b/src/StaticContentHandler.cpp
@@ -4,8 +4,6 @@ StaticContentHandler::StaticContentHandler()
 {
 }
 
-StaticContentHandler::StaticContentHandler(const std::string &webRoot) : _webRoot(webRoot) {};
-
 StaticContentHandler::~StaticContentHandler()
 {
 }

--- a/src/StaticContentHandler.hpp
+++ b/src/StaticContentHandler.hpp
@@ -25,7 +25,6 @@ class StaticContentHandler : public AResponseHandler
 	void handleNotFound(HTTPResponse &response);
 
   private:
-	std::string _webRoot;
 	StaticContentHandler(const StaticContentHandler &other);
 	StaticContentHandler &operator=(const StaticContentHandler &other);
 };

--- a/src/UploadHandler.cpp
+++ b/src/UploadHandler.cpp
@@ -5,8 +5,6 @@ UploadHandler::UploadHandler()
 {
 }
 
-UploadHandler::UploadHandler(const std::string &webRoot) : _webRoot(webRoot) {};
-
 UploadHandler::~UploadHandler()
 {
 }

--- a/tests/general_tests.py
+++ b/tests/general_tests.py
@@ -3,102 +3,124 @@ import aiofiles
 import aiohttp
 import sys
 
-GREEN = '\033[92m'
-RED = '\033[91m'
-RESET = '\033[0m'
+GREEN = "\033[92m"
+RED = "\033[91m"
+RESET = "\033[0m"
 
 BUFFER_SIZE = 1024
 
 headers_buffer_size = {
-	"Host": "www.example.com",
-    "X-Custom-Header": "A" * (BUFFER_SIZE + 1)
+    "Host": "www.example.com",
+    "X-Custom-Header": "A" * (BUFFER_SIZE + 1),
 }
 
-headers_8kb = {
-	"Host": "www.example.com",
-    "X-Custom-Header": "A" * (BUFFER_SIZE * 8)
-}
+headers_8kb = {"Host": "www.example.com", "X-Custom-Header": "A" * (BUFFER_SIZE * 8)}
 
 headers_chunked = {
     "Host": "www.example.com",
 }
-correct_headers = {
-	"Host": "www.example.com"
-}
+correct_headers = {"Host": "www.example.com"}
 
 url = "http://localhost:8080/index.html"
 
+
 async def print_message(status, expected_status, message):
-	global is_error
-	if status == expected_status:
-		print(GREEN + f"{status} OK " + message + RESET)
-	else:
-		print(RED + f"{status} KO " + message + RESET)
-		is_error = True
+    global is_error
+    if status == expected_status:
+        print(GREEN + f"{status} OK " + message + RESET)
+    else:
+        print(RED + f"{status} KO " + message + RESET)
+        is_error = True
+
 
 async def upload_multiple_file():
-	async with aiohttp.ClientSession() as session:
-		data = aiohttp.FormData()
-		file_paths = ["a.txt", "b.txt", "c.txt"]
-		for file_path in file_paths:
-			data.add_field('file',open(file_path, 'rb'), filename=file_path, content_type='text/tab-separated-values')
-		async with session.post(url, headers=correct_headers, data=data) as response:
-			await print_message(response.status, 200, "multiple file upload")
+    async with aiohttp.ClientSession() as session:
+        data = aiohttp.FormData()
+        file_paths = ["a.txt", "b.txt", "c.txt"]
+        for file_path in file_paths:
+            data.add_field(
+                "file",
+                open(file_path, "rb"),
+                filename=file_path,
+                content_type="text/tab-separated-values",
+            )
+        async with session.post(url, headers=correct_headers, data=data) as response:
+            await print_message(response.status, 200, "multiple file upload")
+
 
 async def upload_large_file(file_name):
-	async with aiohttp.ClientSession() as session:
-		data = aiohttp.FormData()
-		data.add_field('file',open(file_name, 'rb'), filename=file_name, content_type='text/tab-separated-values')
-		async with session.post(url, headers=correct_headers, data=data) as response:
-			await print_message(response.status, 200, "file upload")
+    async with aiohttp.ClientSession() as session:
+        data = aiohttp.FormData()
+        data.add_field(
+            "file",
+            open(file_name, "rb"),
+            filename=file_name,
+            content_type="text/tab-separated-values",
+        )
+        async with session.post(url, headers=correct_headers, data=data) as response:
+            await print_message(response.status, 200, "file upload")
+
 
 async def upload_file(file_name):
-	async with aiohttp.ClientSession() as session:
-		data = aiohttp.FormData()
-		data.add_field('file',open(file_name, 'rb'), filename=file_name, content_type='text/tab-separated-values')
-		async with session.post(url, headers=correct_headers, data=data) as response:
-			await print_message(response.status, 200, "file upload")
+    async with aiohttp.ClientSession() as session:
+        data = aiohttp.FormData()
+        data.add_field(
+            "file",
+            open(file_name, "rb"),
+            filename=file_name,
+            content_type="text/tab-separated-values",
+        )
+        async with session.post(url, headers=correct_headers, data=data) as response:
+            await print_message(response.status, 200, "file upload")
+
 
 async def func_headers_8kb():
-	async with aiohttp.ClientSession() as session:
-		async with session.get(url, headers=headers_8kb) as response:
-			await print_message(response.status, 431, "headers > 8KB")
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers_8kb) as response:
+            await print_message(response.status, 431, "headers > 8KB")
+
 
 async def func_headers_buffer_size():
-	async with aiohttp.ClientSession() as session:
-		async with session.get(url, headers=headers_buffer_size) as response:
-			await print_message(response.status, 200, "headers > buffer_size")
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers_buffer_size) as response:
+            await print_message(response.status, 200, "headers > buffer_size")
+
 
 async def file_sender(file_name):
-	try:
-		async with aiofiles.open(file_name, 'rb') as f:
-			chunk = await f.read(900)  # 900 bytes chunks
-			while chunk:
-				yield chunk
-				chunk = await f.read(1024)
-		print("Finished reading file.")
-	except Exception as e:
-		print(f"Error during file reading: {e}")
+    try:
+        async with aiofiles.open(file_name, "rb") as f:
+            chunk = await f.read(900)  # 900 bytes chunks
+            while chunk:
+                yield chunk
+                chunk = await f.read(1024)
+        print("Finished reading file.")
+    except Exception as e:
+        print(f"Error during file reading: {e}")
+
 
 async def send_chunked_request(file_name):
-	async with aiohttp.ClientSession() as session:
-		async with session.post(url, headers=headers_chunked, data=file_sender(file_name)) as response:
-			 await print_message(response.status, 200, "chunked request with file")
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            url, headers=headers_chunked, data=file_sender(file_name)
+        ) as response:
+            await print_message(response.status, 200, "chunked request with file")
+
 
 # send requests async
 async def main():
-	global is_error
+    global is_error
 
-	is_error = False
-	# await upload_large_file("5mb.jpg") # large file to test non-blocking
-	await func_headers_buffer_size() # header bigger than 1024 bytes(server should read in multiple reads)
-	await func_headers_8kb() # header bigger than 8KB (server should send 431)
-	await upload_file("a.txt") # upload singe small file
-	await upload_multiple_file() # upload 3 files at the same time (in one POST request)
-	await send_chunked_request("5mb.jpg") # chunked request with file
-	if (is_error == True):
-		sys.exit(1)
-	sys.exit(0)
+    is_error = False
+    # await upload_large_file("5mb.jpg") # large file to test non-blocking
+    await func_headers_buffer_size()  # header bigger than 1024 bytes(server should read in multiple reads)
+    await func_headers_8kb()  # header bigger than 8KB (server should send 431)
+    await upload_file("a.txt")  # upload singe small file
+    await upload_multiple_file()  # upload 3 files at the same time (in one POST request)
+    await send_chunked_request("5mb.jpg")  # chunked request with file
+    if is_error == True:
+        sys.exit(1)
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
The Server parameter constructor fills the _config property of the Server with the Config object created from the config file, but it loads anyway some default property some of them seems not to be used anymore. 

- [x] delete functions loading the config and the default config cause they are not used.
- [x] check if the properties of the Server are still used and how are they filled at initialisation
- [x] remove _webRoot (multiple finding also on other objects)
- [x] check _maxClients: seems legit
- [x] check _clientMaxBodySize
- [x] check _clientMaxHeadersSize (the macro is used but not the property)
- [x] check _port: (never used)